### PR TITLE
Added an "regex" option for the interface resolver

### DIFF
--- a/example_config.toml
+++ b/example_config.toml
@@ -57,6 +57,7 @@ address = "2001:DB8:123:abcd::1"
 type = "interface"
 interface = "eth0"
 network = "0.0.0.0/32"
+regex = false # If the interface should be filtered using a regex
 
 # IP address sources of type "derived" combine the host part and the net part of two other "ip" entries to create a new
 # IP address. The "subnet_entry" and the "host_entry" configuration options define which other IP addresses should be

--- a/src/config.rs
+++ b/src/config.rs
@@ -447,6 +447,8 @@ pub struct IpAddressDerived {
 pub struct IpAddressInterface {
     pub interface: String,
     pub network: String,
+    #[serde(default = "get_false")]
+    pub regex: bool
 }
 
 pub fn read_config(config_file: &Path) -> Result<Config, Error> {
@@ -517,6 +519,7 @@ address = "2001:DB8:123:abcd::1"
 type = "interface"
 interface = "eth0"
 network = "::/0"
+regex = false
 
 [ip.calculated_address]
 type = "derived"
@@ -583,6 +586,7 @@ replace = "myAddr={some_static_addr}"
             IpAddress::Interface(IpAddressInterface {
                 interface: "eth0".parse().unwrap(),
                 network: "::/0".parse().unwrap(),
+                regex: false
             }),
         );
         ip_addresses.insert(

--- a/src/resolver/resolver_interface.rs
+++ b/src/resolver/resolver_interface.rs
@@ -2,6 +2,7 @@ use crate::config::IpAddressInterface;
 use ipnetwork::IpNetwork;
 use pnet::datalink::{interfaces, NetworkInterface};
 use std::net::IpAddr;
+use regex::{Error, Regex};
 
 pub fn resolve_interface(config: &IpAddressInterface) -> Option<IpAddr> {
     config
@@ -15,15 +16,25 @@ pub fn resolve_interface(config: &IpAddressInterface) -> Option<IpAddr> {
         })
         .ok()
         .and_then(|network| {
-            get_interface(&config.interface).and_then(|iface| get_ip_address(&iface, &network))
+            get_interface(&config.interface, config.regex).and_then(|iface| get_ip_address(&iface, &network))
         })
 }
 
-fn get_interface(name: &str) -> Option<NetworkInterface> {
-    interfaces()
-        .into_iter()
-        .filter(|iface| iface.name == name)
-        .next()
+fn get_interface(name: &str, regex: bool) -> Option<NetworkInterface> {
+    if regex {
+        match Regex::new(name) {
+            Ok(regex) => interfaces()
+                .into_iter()
+                .filter(|iface| regex.is_match(&iface.name))
+                .next(),
+            Err(err) => None,
+        }
+    } else {
+        interfaces()
+            .into_iter()
+            .filter(|iface| iface.name == name)
+            .next()
+    }
 }
 
 fn get_ip_address(iface: &NetworkInterface, expected_network: &IpNetwork) -> Option<IpAddr> {

--- a/src/resolver/resolver_interface.rs
+++ b/src/resolver/resolver_interface.rs
@@ -2,7 +2,7 @@ use crate::config::IpAddressInterface;
 use ipnetwork::IpNetwork;
 use pnet::datalink::{interfaces, NetworkInterface};
 use std::net::IpAddr;
-use regex::{Error, Regex};
+use regex::Regex;
 
 pub fn resolve_interface(config: &IpAddressInterface) -> Option<IpAddr> {
     config
@@ -27,7 +27,10 @@ fn get_interface(name: &str, regex: bool) -> Option<NetworkInterface> {
                 .into_iter()
                 .filter(|iface| regex.is_match(&iface.name))
                 .next(),
-            Err(err) => None,
+            Err(_err) => {
+                warn!("The regex \"{}\" couldn't be compiled.", name);
+                None
+            },
         }
     } else {
         interfaces()


### PR DESCRIPTION
I added a "regex" option to the interface resolver, which will then check the interface name against the regex instead of comparing it.

It is meant for network interfaces which changes their names after a reboot.